### PR TITLE
Feat/mario/correct import in setup

### DIFF
--- a/feeds/__init__.py
+++ b/feeds/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '2.0.0'  # pragma: no cover
+__version__ = '0.8'  # pragma: no cover

--- a/feeds/__init__.py
+++ b/feeds/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+__version__ = '2.0.0'  # pragma: no cover

--- a/feeds/__init__.py
+++ b/feeds/__init__.py
@@ -1,2 +1,2 @@
 # -*- coding: utf-8 -*-
-__version__ = '0.8'  # pragma: no cover
+__version__ = '0.0.8'  # pragma: no cover

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ django-storages==1.5.2
 boto3==1.9.70
 memoized-property==1.0.2
 django-model-helpers>=1.2.1
-html2text==2015.11.4
+html2text>=2015.4.14,<=2015.11.4
 pep8==1.6.2
 requests==2.12.4
 python-memcached==1.59

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,7 +35,7 @@ memoized-property==1.0.2
 django-model-helpers>=1.2.1
 html2text==2015.11.4
 pep8==1.6.2
-requests==2.9.1
+requests==2.12.4
 python-memcached==1.59
 # libraries needed by requests to avoid the error:
 # extension to TLS is not available on this platform.
@@ -47,5 +47,5 @@ pyasn1==0.1.9
 stravalib==0.5.0
 Unirest==1.1.6
 healthgraph-api==0.3.0
-requests-oauthlib==0.4.2
-oauthlib==1.0.3
+requests-oauthlib==0.7.0
+oauthlib==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-filter==0.10.0
 
 pylint==1.6.4
 pylint-django==0.7.2
-psycopg2==2.7
+psycopg2>=2.5.4,<=2.7
 django-annoying==0.8.4
 django-tinymce==2.0.5
 django-redis==4.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,8 +44,6 @@ pyOpenSSL==16.2.0
 ndg-httpsclient==0.4.2
 pyasn1==0.1.9
 #connect apps
-stravalib==0.5.0
 Unirest==1.1.6
-healthgraph-api==0.3.0
 requests-oauthlib==0.7.0
 oauthlib==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ django-filter==0.10.0
 
 pylint==1.6.4
 pylint-django==0.7.2
-psycopg2>=2.5.4,<=2.7
+psycopg2>=2.5.4,<=2.8.4
 django-annoying==0.8.4
 django-tinymce==2.0.5
 django-redis==4.8.0

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ http://docs.python.org/2/distutils/sourcedist.html
 """
 import os
 from setuptools import setup, find_packages
-import rewardz_user_importer as app
+import feeds as app
 
 
 dev_requires = [


### PR DESCRIPTION
Had to make some corrections to allow Flabuless to be installed from scratch, rather than in an already existing environment (Like a docker image I use for development).

First corrected the "import rewardz_user_importer as app" for "import feeds as app", this was causing the error I mentioned to Piklu on Skype, as this package doesn't have a rewardz_user_importer package and would error out when deploying a new server. Also this causes the feeds package to have whatever version of the already installed rewardz_user_importer, so "feeds" in flabuless was version 1.13, while on Cerra I believe it's version 1.32. This is gonna cause update problems on places where this package has already been deployed. I left the bumped version as "0.0.8" while correcting the import, but I suggest bumping all the way to 2.0.0 to avoid this. But leave it to you guys to make this call as I don't know where this package has already been deployed. 

Then I corrected some dependencies that were also causing conflict with Flabuless versions. These dependencies don't seem to be doing anything in particular from a cursory look on the package, so I'm guessing this won't be an issue.

Then I removed other dependencies, like strava and runkeeper, as they were conflicting and also seems that they are not used for the package. 

I'm changing the flabuless requirements.txt to point to my fork of the package for now, otherwise installs from scratch get borked and this would be scary in prod.