### PR TITLE
Admin post should send the creation notification

### DIFF
--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -259,7 +259,7 @@ def notify_new_comment(comment, creator):
 
 def notify_new_post_poll_created(poll, is_post=False):
     creator = poll.created_by
-    if poll.post_type == POST_TYPE.USER_CREATED_POST and not creator.is_staff:
+    if not creator.is_staff:
         return
     accessible_users = []
     if poll.shared_with == SHARED_WITH.SELF_DEPARTMENT:

--- a/feeds/utils.py
+++ b/feeds/utils.py
@@ -259,6 +259,8 @@ def notify_new_comment(comment, creator):
 
 def notify_new_post_poll_created(poll, is_post=False):
     creator = poll.created_by
+    if poll.post_type == POST_TYPE.USER_CREATED_POST and not creator.is_staff:
+        return
     accessible_users = []
     if poll.shared_with == SHARED_WITH.SELF_DEPARTMENT:
         departments = creator.departments.all()


### PR DESCRIPTION
Post/polls creation notifications should be sent to related users if the post is created by the admin (is_staff=True)

If normal user is not able to creates the post then no notification should be sent


cc: @SteffiVinod5 @suryaiiit 