### PR TITLE
improve organization recoganization API performance

### DIFF
--- a/feeds/paginator.py
+++ b/feeds/paginator.py
@@ -1,8 +1,15 @@
 from __future__ import division, print_function, unicode_literals
 
 from django.conf import settings
+from django.utils import six
 
+from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.compat import OrderedDict
+from rest_framework.exceptions import NotFound
+from rest_framework.utils.urls import (
+    replace_query_param, remove_query_param
+)
 
 
 class FeedsResultsSetPagination(PageNumberPagination):
@@ -22,6 +29,58 @@ class FeedsResultsSetPagination(PageNumberPagination):
         except AttributeError as ae:
             page_size = 20
         return page_size
+
+    def get_next_link(self):
+        url = self.request.build_absolute_uri()
+        current_page_number = int(self.request.query_params.get(self.page_query_param, 1))
+        page_number = current_page_number + 1
+        return replace_query_param(url, self.page_query_param, page_number)
+
+    def get_previous_link(self):
+        current_page_number = int(self.request.query_params.get(self.page_query_param, 1))
+        page_number = current_page_number - 1
+        if page_number == 0:
+            return None
+        url = self.request.build_absolute_uri()
+        if page_number == 1:
+            return remove_query_param(url, self.page_query_param)
+        return replace_query_param(url, self.page_query_param, page_number)
+
+    def get_paginated_response(self, data):
+        return Response(OrderedDict([
+            ('next', self.get_next_link()),
+            ('previous', self.get_previous_link()),
+            ('results', data)
+        ]))
+
+    def paginate_queryset(self, queryset, request, view=None):
+        """
+        Modified from DRF. Skip count() call.
+        """
+        self._handle_backwards_compat(view)
+
+        page_size = self.get_page_size(request)
+        if not page_size:
+            return None
+
+        try:
+            page_number = int(request.query_params.get(self.page_query_param, 1))
+        except ValueError as exc:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message=six.text_type(exc)
+            )
+            raise NotFound(msg)
+
+        result = queryset[page_size * (page_number - 1):page_size * page_number]
+
+        if len(result) == 0:
+            msg = self.invalid_page_message.format(
+                page_number=page_number, message="Empty page"
+            )
+            raise NotFound(msg)
+
+        self.request = request
+        return list(result)
 
 
 class FeedsCommentsSetPagination(PageNumberPagination):

--- a/feeds/paginator.py
+++ b/feeds/paginator.py
@@ -28,7 +28,7 @@ class FeedsResultsSetPagination(PageNumberPagination):
         return page_size
 
 
-class UserFeedsResultsSetPagination(FeedsResultsSetPagination):
+class OrganizationRecognitionsPagination(FeedsResultsSetPagination):
 
     def get_next_link(self):
         url = self.request.build_absolute_uri()

--- a/feeds/paginator.py
+++ b/feeds/paginator.py
@@ -2,14 +2,11 @@ from __future__ import division, print_function, unicode_literals
 
 from django.conf import settings
 from django.utils import six
-
-from rest_framework.response import Response
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.compat import OrderedDict
 from rest_framework.exceptions import NotFound
-from rest_framework.utils.urls import (
-    replace_query_param, remove_query_param
-)
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from rest_framework.utils.urls import remove_query_param, replace_query_param
 
 
 class FeedsResultsSetPagination(PageNumberPagination):
@@ -29,6 +26,9 @@ class FeedsResultsSetPagination(PageNumberPagination):
         except AttributeError as ae:
             page_size = 20
         return page_size
+
+
+class UserFeedsResultsSetPagination(FeedsResultsSetPagination):
 
     def get_next_link(self):
         url = self.request.build_absolute_uri()

--- a/feeds/paginator.py
+++ b/feeds/paginator.py
@@ -48,6 +48,7 @@ class FeedsResultsSetPagination(PageNumberPagination):
 
     def get_paginated_response(self, data):
         return Response(OrderedDict([
+            ('count', 1000),  # hard coded for now cause Android need it to be greater than 0 when not empty
             ('next', self.get_next_link()),
             ('previous', self.get_previous_link()),
             ('results', data)

--- a/feeds/views.py
+++ b/feeds/views.py
@@ -340,7 +340,7 @@ class PostViewSet(viewsets.ModelViewSet):
 
         result = (result | posts_shared_with_org_department(
             user, [POST_TYPE.USER_CREATED_POST, POST_TYPE.USER_CREATED_POLL],
-            result.values_list("id", flat=True))).distinct()
+            [])).distinct()
 
         result = PostFilter(self.request.GET, queryset=result).qs
         result = result.order_by('-priority', '-modified_on', '-created_on')
@@ -1278,7 +1278,7 @@ class UserFeedViewSet(viewsets.ModelViewSet):
         if post_polls:
             feeds = (feeds | posts_shared_with_org_department(
                 user, [POST_TYPE.USER_CREATED_POST, POST_TYPE.USER_CREATED_POLL],
-                feeds.values_list("id", flat=True))).distinct()
+                []).distinct()
         if search:
             feeds = feeds.filter(
                 Q(user__first_name__icontains=search) |

--- a/feeds/views.py
+++ b/feeds/views.py
@@ -902,7 +902,7 @@ class ECardCategoryViewSet(viewsets.ModelViewSet):
         user = self.request.user
         query = Q(organization=user.organization) | Q(organization__isnull=True)
         if self.request.query_params.get('admin_function'):
-            query =  Q(organization=user.organization)
+            query = Q(organization=user.organization)
         queryset = ECardCategory.objects.filter(query)
         queryset = queryset.annotate(custom_order=Case(When(organization=user.organization, then=0),
                                      default=1, output_field=IntegerField())).order_by('custom_order')
@@ -918,7 +918,7 @@ class ECardViewSet(viewsets.ModelViewSet):
         user = self.request.user
         query = Q(category__organization=user.organization) | Q(category__organization__isnull=True)
         if self.request.query_params.get('admin_function'):
-            query =  Q(category__organization=user.organization)
+            query = Q(category__organization=user.organization)
         queryset = ECard.objects.filter(query)
         queryset = queryset.annotate(custom_order=Case(When(category__organization=user.organization, then=0),
                                      default=1, output_field=IntegerField())).order_by('custom_order')
@@ -1174,7 +1174,7 @@ class UserFeedViewSet(viewsets.ModelViewSet):
         serializer = PostFeedSerializer(page, context={"request": request}, many=True)
         feeds = self.get_paginated_response(serializer.data)
         user_appreciation = posts.filter(post_type=POST_TYPE.USER_CREATED_APPRECIATION,
-                                                created_by=request.user).first()
+                                         created_by=request.user).first()
         if user_appreciation:
             days_passed = since_last_appreciation(user_appreciation.created_on)
             if 3 <= days_passed <= 120:
@@ -1278,7 +1278,7 @@ class UserFeedViewSet(viewsets.ModelViewSet):
         if post_polls:
             feeds = (feeds | posts_shared_with_org_department(
                 user, [POST_TYPE.USER_CREATED_POST, POST_TYPE.USER_CREATED_POLL],
-                []).distinct()
+                [])).distinct()
         if search:
             feeds = feeds.filter(
                 Q(user__first_name__icontains=search) |

--- a/feeds/views.py
+++ b/feeds/views.py
@@ -21,7 +21,8 @@ from .models import (
     Comment, Documents, ECard, ECardCategory,
     Post, PostLiked, PollsAnswer, Images, CommentLiked,
 )
-from .paginator import FeedsResultsSetPagination, FeedsCommentsSetPagination
+from .paginator import (
+    FeedsResultsSetPagination, FeedsCommentsSetPagination, UserFeedsResultsSetPagination)
 from .permissions import IsOptionsOrAuthenticated
 from .serializers import (
     CommentDetailSerializer, CommentSerializer, CommentCreateSerializer,
@@ -956,7 +957,7 @@ class UserFeedViewSet(viewsets.ModelViewSet):
     permission_classes = (IsOptionsOrAuthenticated,)
     serializer_class = PostFeedSerializer
     filter_backends = (filters.DjangoFilterBackend,)
-    pagination_class = FeedsResultsSetPagination
+    pagination_class = UserFeedsResultsSetPagination
 
     @staticmethod
     def get_filtered_feeds_according_to_shared_with(feeds, user, post_polls):

--- a/feeds/views.py
+++ b/feeds/views.py
@@ -22,7 +22,7 @@ from .models import (
     Post, PostLiked, PollsAnswer, Images, CommentLiked,
 )
 from .paginator import (
-    FeedsResultsSetPagination, FeedsCommentsSetPagination, UserFeedsResultsSetPagination)
+    FeedsResultsSetPagination, FeedsCommentsSetPagination, OrganizationRecognitionsPagination)
 from .permissions import IsOptionsOrAuthenticated
 from .serializers import (
     CommentDetailSerializer, CommentSerializer, CommentCreateSerializer,
@@ -957,7 +957,23 @@ class UserFeedViewSet(viewsets.ModelViewSet):
     permission_classes = (IsOptionsOrAuthenticated,)
     serializer_class = PostFeedSerializer
     filter_backends = (filters.DjangoFilterBackend,)
-    pagination_class = UserFeedsResultsSetPagination
+    pagination_class = FeedsResultsSetPagination
+
+    @property
+    def paginator(self):
+        """The paginator instance associated with the view, or `None`."""
+        pagination_class = self.get_pagination_class()
+        if not hasattr(self, '_paginator'):
+            if pagination_class is None:
+                self._paginator = None
+            else:
+                self._paginator = pagination_class()
+        return self._paginator
+
+    def get_pagination_class(self):
+        if "organization_recognitions" in self.request.path:
+            return OrganizationRecognitionsPagination
+        return self.pagination_class
 
     @staticmethod
     def get_filtered_feeds_according_to_shared_with(feeds, user, post_polls):


### PR DESCRIPTION
No functionality change. The API response should be 1/3 ~ 1/2 shorter.

Changes on the API:
- no "count" in the response (indicating how many responses are totally there)
- when reaching the last page, the "next_link" field won't show "last", and will just show a normal URL with next page_number. 
- when visiting with page_number out of range, it'll return 404 (this is the same as before)

Please double check this won't break web/mobile. 