### PR TITLE
Fix: post apprciation should return the accessible post appreciation

### DIFF
--- a/feeds/views.py
+++ b/feeds/views.py
@@ -707,11 +707,12 @@ class PostViewSet(viewsets.ModelViewSet):
     @detail_route(methods=["GET"], permission_classes=(IsOptionsOrAuthenticated,))
     def post_appreciations(self, request, *args, **kwargs):
         user = self.request.user
+        organization = user.organization
         post_id = self.kwargs.get("pk", None)
         recent = request.query_params.get("recent", None)
         reaction_type = request.query_params.get("reaction_type", None)
         # Q(organizations__in=user.get_affiliated_orgs()) | Q(organizations__isnull=True)
-        post = Post.objects.get(id=post_id)
+        post = self.get_post_by_id(user, organization, False, is_appreciation_post(post_id), post_id, Q(id=post_id))
         post_likes = post.postliked_set.all().order_by("-id")
         all_reaction_count = post_likes.count()
         if recent:


### PR DESCRIPTION
https://github.com/rewardz/skor/issues/9045

Retest Update:- This Finding is still outstanding. A user from Org A can view the details of a post from Org B [PFA](https://github.com/user-attachments/assets/4c097636-02c0-490f-b21e-82820f3b4aca)

Description :-
The application restricts users from directly viewing posts made by users in organizations outside
their own.
However, it was discovered that users can view appreciation details (such as likes or reactions) on
these external posts by knowing the post's ID. Given that post IDs are five digits long and
incremental, users can easily enumerate through the IDs to access this information. This allows
users to see not only the appreciation count but also the details of the users who interacted with
those posts, circumventing the intended access restrictions between organizations.
The exposed endpoint returns a significant amount of user metadata, including first and last names,
email addresses, department name, profile pictures, and join dates. This effectively leads to a large -
scale information disclosure, enabling malicious actors to scrape user data from the entire database,
violating user privacy and exposing sensitive organizational information.
The vulnerable APIs are summarized in the below:
HTTP Method- GET
Vulnerable URL- https://cerrapoints.com/feeds/api/posts/<POST_ID>/post_appreciations/
Vulnerable Parameter- POST_ID in the URL

Steps to reproduce:

Attacker visits his feed, and visits any post [PFA](https://github.com/user-attachments/assets/aae14572-2ee2-4e0b-b34d-451dae116073)
Attacker intercepts the request responsible for getting the appreciations for this post [PFA](https://github.com/user-attachments/assets/cddfd0a7-b60a-433a-8718-4a2990b69d6a)
Attacker modifies the request, changing the post ID to a post ID that is outside of his organization,
and can successfully get information about that post's appreciations [PFA](https://github.com/user-attachments/assets/72d2fcc3-6faa-4fe1-b100-fdabcc2e5443)
Recommendation :-
Implement access controls to restrict users from viewing appreciation details on posts outside their
organization.